### PR TITLE
fix: windowPosition option is overwritten on Windows and Linux

### DIFF
--- a/src/Menubar.ts
+++ b/src/Menubar.ts
@@ -141,7 +141,7 @@ export class Menubar extends EventEmitter {
 
 		// 'Windows' taskbar: sync windows position each time before showing
 		// https://github.com/maxogden/menubar/issues/232
-		if (['win32', 'linux'].includes(process.platform)) {
+		if (['win32', 'linux'].includes(process.platform) && !this._options.windowPosition) {
 			// Fill in this._options.windowPosition when taskbar position is available
 			this._options.windowPosition = getWindowPosition(this.tray);
 		}

--- a/src/Menubar.ts
+++ b/src/Menubar.ts
@@ -141,7 +141,10 @@ export class Menubar extends EventEmitter {
 
 		// 'Windows' taskbar: sync windows position each time before showing
 		// https://github.com/maxogden/menubar/issues/232
-		if (['win32', 'linux'].includes(process.platform) && !this._options.windowPosition) {
+		if (
+			['win32', 'linux'].includes(process.platform) &&
+			!this._options.windowPosition
+		) {
 			// Fill in this._options.windowPosition when taskbar position is available
 			this._options.windowPosition = getWindowPosition(this.tray);
 		}


### PR DESCRIPTION
`menubar` allows user to customize `windowPosition` : https://github.com/maxogden/menubar/blob/2ee2e6ab4991a5dd922d7f073d99dcc7a7802081/README.md?plain=1#L96 but this value is not respected/overwritten on Windows and Linux. This PR fixes the issue.