### PR TITLE
Fix for Broken Native Menubar Example

### DIFF
--- a/examples/native-menu/main.js
+++ b/examples/native-menu/main.js
@@ -21,6 +21,7 @@ app.on('ready', () => {
 
 	mb.on('ready', () => {
 		// needed for macos to remove white screen
+		// ref: https://github.com/max-mapper/menubar/issues/345
 		tray.removeAllListeners();
 		
 		console.log('Menubar app is ready.');

--- a/examples/native-menu/main.js
+++ b/examples/native-menu/main.js
@@ -20,6 +20,9 @@ app.on('ready', () => {
 	});
 
 	mb.on('ready', () => {
+		// needed for macos to remove white screen
+		tray.removeAllListeners();
+		
 		console.log('Menubar app is ready.');
 		// your app code here
 	});


### PR DESCRIPTION
Hey Guys!

I've addressed the issue where the native menubar example was acting up. The problem was that clicking the icon in the menubar was opening both the native menu and the browser window, which wasn't the expected behavior. This seems to only happen on MacOS.

```javascript
mb.on('ready', () => {
    console.log('Menubar app is ready.');
    // Your app code here
    tray.removeAllListeners(); // Removed unnecessary event listeners
});
```

## Additional Notes:
I want to give credit where it's due: @Jip-Hop initially identified the issue and provided a workaround. Thanks to them for pointing it out! I've just created a pull request.

