### PR TITLE
Add disable click option

### DIFF
--- a/src/Menubar.ts
+++ b/src/Menubar.ts
@@ -222,11 +222,13 @@ export class Menubar extends EventEmitter {
     if (!this.tray) {
       throw new Error('Tray has been initialized above');
     }
-    this.tray.on(
-      defaultClickEvent as Parameters<Tray['on']>[0],
-      this.clicked.bind(this),
-    );
-    this.tray.on('double-click', this.clicked.bind(this));
+    if (this._options.disableClick != true) {
+      this.tray.on(
+        defaultClickEvent as Parameters<Tray['on']>[0],
+        this.clicked.bind(this),
+      );
+      this.tray.on('double-click', this.clicked.bind(this));
+    }
     this.tray.setToolTip(this._options.tooltip);
 
     if (!this._options.windowPosition) {
@@ -293,8 +295,8 @@ export class Menubar extends EventEmitter {
       this._browserWindow.isAlwaysOnTop()
         ? this.emit('focus-lost')
         : (this._blurTimeout = setTimeout(() => {
-            this.hideWindow();
-          }, 100));
+          this.hideWindow();
+        }, 100));
     });
 
     if (this._options.showOnAllWorkspaces !== false) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,10 @@ export interface Options {
    */
   showOnRightClick?: boolean;
   /**
+   * Don't show the window at all if clicked
+   */
+  disableClick?: boolean;
+  /**
    * Menubar tray icon tooltip text. Calls [`tray.setTooltip`](https://electronjs.org/docs/api/tray#traysettooltiptooltip).
    */
   tooltip: string;


### PR DESCRIPTION
Added disableClick which will disable the opening of the window when the user clicks the tray icon. You can still use showWindow to open the window.

This allows for multiple windows to be assigned to a tray icon. In my instance i have the main window still assigned to the default option, and a about window which has disableClick=true which is opened via a context menu. Both windows open under the tray icon nicely :)
<img width="985" alt="image" src="https://github.com/user-attachments/assets/3c44ccc5-ad1d-4e85-b237-7433a2b61612">
<img width="375" alt="image" src="https://github.com/user-attachments/assets/12cb5e73-9662-4de1-b6f9-ac55b96b1bc3">
