### PR TITLE
add npm script `prepare`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/maxogden/menubar.git"
   },
   "scripts": {
+    "prepare": "npm run build",
     "build": "rimraf lib/ && tsc",
     "deploy": "yarn build && standard-version",
     "docs": "typedoc",


### PR DESCRIPTION
so when the repo is depended on via npm git dep, it builds the ts to js referenced by the package.json.

I tried this on my fork and verified it enabled me to install the branch via npm git dep
https://github.com/gobengo/menubar/commit/7f0c171b10bb40fa2aeeb0656ef0fd50a3f5cd23

(when package.json has a prepare script, then when npm loads it as a dependency in certain contexts outside of npm registry, then it will include devDeps and can then run `tsc` in the prepare script when being installed by a dependent)